### PR TITLE
Fix bugs in score/reputation system

### DIFF
--- a/src/social/functions.rs
+++ b/src/social/functions.rs
@@ -95,6 +95,8 @@ impl<T: Trait> Module<T> {
 
   pub fn change_post_score(account: T::AccountId, post: &mut Post<T>, action: ScoringAction) -> Result {
     let social_account = Self::get_or_new_social_account(account.clone());
+    <SocialAccountById<T>>::insert(account.clone(), social_account.clone());
+
     let post_id = post.id;
     let mut blog = Self::blog_by_id(post.blog_id).ok_or(MSG_BLOG_NOT_FOUND)?;
     
@@ -135,6 +137,8 @@ impl<T: Trait> Module<T> {
 
   pub fn change_comment_score(account: T::AccountId, comment: &mut Comment<T>, action: ScoringAction) -> Result {
     let social_account = Self::get_or_new_social_account(account.clone());
+    <SocialAccountById<T>>::insert(account.clone(), social_account.clone());
+
     let comment_id = comment.id;
 
     if comment.created.account != account {


### PR DESCRIPTION
- Fix tests to use new defaults and messages files
- Now tests don't use function change_score itself, but extrinsics that should call it.
- Now tests check social account reputation correctly
- Fix social account storaging when scoring at the first time
- Add reverting and deleting score diff, when undoing action that caused it